### PR TITLE
resolves #57 - expand advanced search to include zip, city, address, and coop type

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,7 @@ import { Alert } from "reactstrap";
 import NavBar from "./components/NavBar";
 import Add from "./components/Add";
 import Edit from "./components/Edit";
+import AdvancedSearch from './components/AdvancedSearch';
 import Search from "./components/Search";
 import NoCoordsSearch from "./components/NoCoordsSearch";
 import DirectoryAddUpdate from "./components/DirectoryAddUpdate";
@@ -38,6 +39,7 @@ function App() {
               <Switch>
                 <Route exact path="/" component={Add} />
                 <Route path="/add" component={Add} />
+                <Route path="/advanced" component={AdvancedSearch} />
                 <Route path="/edit/:id" component={Edit} />
                 <Route path="/search" component={Search} />
                 <Route path="/nocoords" component={NoCoordsSearch} />


### PR DESCRIPTION
* I added the ability to perform a search on zip, city, address, and coop type.
* I also fixed a bug discovered on Issue #13 (https://github.com/chicommons/maps/commit/77d4ae839a9681273bfcd67e1efdeabfd824261d) where no search results loaded if a user hit "submit" without changing any of the default form settings. Now, all search results will return if the user submits the form as-is, without making any changes.