### PR TITLE
Client-side form validation, including contact info

### DIFF
--- a/client/src/components/DirectoryAddUpdate.jsx
+++ b/client/src/components/DirectoryAddUpdate.jsx
@@ -261,7 +261,7 @@ export default function DirectoryAddUpdate() {
           onSubmit={submitForm}
           className="container-fluid"
           id="directory-add-update"
-          noValidate
+          // noValidate
         >
           <FormGroup>
             <div className="form-row">
@@ -275,6 +275,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Cooperative/entity name"}
                   handleChange={(e) => setCoopName(e.target.value)}
                   errors={errors}
+                  required={1}
                 />{" "}
               </div>
               <div className="form-group col-md-6 col-lg-3 col-xl-3">
@@ -286,6 +287,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Address street"}
                   handleChange={(e) => setStreet(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-4 col-lg-3 col-xl-2">
@@ -297,6 +299,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Address city"}
                   handleChange={(e) => setCity(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-3 col-lg-2 col-xl-2">
@@ -318,6 +321,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Zip code"}
                   handleChange={(e) => setZip(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-3 col-lg-2 col-xl-3">
@@ -329,6 +333,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"County"}
                   handleChange={(e) => setCounty(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-4 col-lg-2 col-xl-3">
@@ -355,6 +360,7 @@ export default function DirectoryAddUpdate() {
                     { id: "yes", name: "Yes" },
                     { id: "no", name: "No" },
                   ]}
+                  required={0}
                 />
               </div>
               <div className="form-group col-md-12">
@@ -369,6 +375,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Website or social media pages"}
                   handleChange={(e) => setWebsites(e.target.value)}
                   errors={errors}
+                  required={1}
                 />{" "}
               </div>
               <div className="form-group col-md-6">
@@ -381,6 +388,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Contact name"}
                   handleChange={(e) => setContactName(e.target.value)}
                   errors={errors}
+                  required={1}
                 />{" "}
               </div>
               <div className="form-group col-md-6">
@@ -397,7 +405,11 @@ export default function DirectoryAddUpdate() {
                     { id: "yes", name: "Yes" },
                     { id: "no", name: "No" },
                   ]}
+                  required={0}
                 />
+              </div>
+              <div className="form-group col-12 form__desc">
+                You must include at least either a phone number or an e-mail address.
               </div>
               <div className="form-group col-md-4 col-lg-4">
                 <Input
@@ -408,6 +420,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Contact email"}
                   handleChange={(e) => setContactEmail(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               {contactEmail ? (
@@ -425,6 +438,7 @@ export default function DirectoryAddUpdate() {
                       { id: "yes", name: "Yes" },
                       { id: "no", name: "No" },
                     ]}
+                    required={1}
                   />
                 </div>
               ) : (
@@ -439,6 +453,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Contact phone"}
                   handleChange={(e) => setContactPhone(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               {contactPhone ? (
@@ -456,11 +471,23 @@ export default function DirectoryAddUpdate() {
                       { id: "yes", name: "Yes" },
                       { id: "no", name: "No" },
                     ]}
+                    required={1}
                   />
                 </div>
               ) : (
                 <div className="form-group col-md-8 col-lg-6"></div>
               )}
+              <div className="col-12">
+                <Input
+                  type={"hidden"}
+                  title={""}
+                  name={"contact"}
+                  value={''}
+                  placeholder={"Contact info"}
+                  errors={errors}
+                  required={0}
+                />{" "}
+              </div>
               <div className="form-group col-md-6 col-lg-6">
                 <DropDownInput
                   className={"required"}
@@ -479,6 +506,7 @@ export default function DirectoryAddUpdate() {
                   }
                   options={entities}
                   errors={errors}
+                  required={1}
                 />
               </div>
               <div className="form-group col-md-6 col-lg-4">
@@ -496,6 +524,7 @@ export default function DirectoryAddUpdate() {
                     { id: "national", name: "National" },
                     { id: "international", name: "International" },
                   ]}
+                  required={0}
                 />
               </div>
               <div className="form-group col-md-12 col-lg-12 col-xl-10">
@@ -507,6 +536,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Enter tags"}
                   handleChange={(e) => setTags(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-12 col-lg-6 col-xl-4">
@@ -519,6 +549,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Enter entity description (English)"}
                   handleChange={(e) => setDescEng(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-12 col-lg-6 col-xl-4">
@@ -531,6 +562,7 @@ export default function DirectoryAddUpdate() {
                   placeholder={"Enter entity description (Other Language)"}
                   handleChange={(e) => setDescOther(e.target.value)}
                   errors={errors}
+                  required={0}
                 />{" "}
               </div>
               <div className="form-group col-md-8 col-lg-8 col-xl-4">
@@ -547,6 +579,7 @@ export default function DirectoryAddUpdate() {
                     { id: "add", name: "Add new record" },
                     { id: "update", name: "Update existing record" },
                   ]}
+                  required={1}
                 />
               </div>
             </div>

--- a/client/src/components/DropDownInput.jsx
+++ b/client/src/components/DropDownInput.jsx
@@ -17,6 +17,7 @@ const DropDownInput = (props) => {
         value={props.value}
         onChange={props.handleChange}
         multiple={props.multiple && "multiple"}
+        required={props.required}
       >
         {!props.multiple && (
           <option value="" disabled>

--- a/client/src/components/Input.jsx
+++ b/client/src/components/Input.jsx
@@ -7,18 +7,24 @@ const Input = (props) => {
 
   return (
     <div className="form-group">
-      <FormLabel className={props.className} style={inputStyle}>
-        {props.title}
-      </FormLabel>
-      <FormControl
-        isInvalid={props.errors && errorsArr}
-        type={props.type}
-        id={props.name}
-        name={props.name}
-        value={props.value}
-        placeholder={props.placeholder}
-        onChange={props.handleChange}
-      />
+        <FormLabel
+          className={props.className}
+          style={inputStyle}
+          visibility={(props.type==='hidden') ? 'hidden' : 'shown'}
+        >
+          {props.title}
+        </FormLabel>
+        <FormControl
+          isInvalid={props.errors && errorsArr}
+          type={props.type}
+          id={props.name}
+          name={props.name}
+          value={props.value}
+          placeholder={props.placeholder}
+          onChange={props.handleChange}
+          required={props.required}
+          visibility={(props.type==='hidden') ? 'hidden' : 'shown'}
+        />
 
       {errorsArr && (
         <FormControl.Feedback type="invalid">


### PR DESCRIPTION
Replaces #129.

Added native HTML validation for required fields including entity name, website, and contact name. Did not add client-side validation for email/phone number, but the form does show an error after it's caught on the back-end.

@DaveyDevs found a minor bug in the back-end validation, the contact info validation occurs after the other required fields, meaning if any other required field is empty, the email/phone error does not get thrown. With the new HTML validation, it may not matter anyways.