### PR TITLE
changes the edit link format on the nocoords page to match search

### DIFF
--- a/client/src/components/NoCoordsSearch.jsx
+++ b/client/src/components/NoCoordsSearch.jsx
@@ -58,7 +58,7 @@ const Search = (props) => {
               <ListGroupItem key={item.id} value={item.name}>
                 {item.name}
                 <span className="float-right">
-                  <Link to={"/edit/" + item.id + "/home"}>
+                  <Link to={"/directory-additions-updates/" + item.id}>
                     <PencilSquare color="RoyalBlue" size={26} />
                   </Link>
                 </span>


### PR DESCRIPTION
Changes the Pencil icon link in nocoords to match the same edit link as in the normal search results