### PR TITLE
Excluding localities with no zip code.

### DIFF
--- a/web/directory/management/commands/parse_coop_csv.py
+++ b/web/directory/management/commands/parse_coop_csv.py
@@ -184,7 +184,6 @@ class Command(BaseCommand):
                 print("    name: \"",city,"\"", sep='')
                 print("    postal_code: \"",zipcode,"\"", sep='')
                 print("    state: ['", state_id, "', '", country, "']", sep='')
-#                print("    state: 19313")
                 cities_pks[tuple(city_set)] = i 
                 i = i + 1
         return cities_pks

--- a/web/directory/management/commands/parse_coop_csv.py
+++ b/web/directory/management/commands/parse_coop_csv.py
@@ -177,14 +177,15 @@ class Command(BaseCommand):
             city = list(city_set)[0]
             zipcode = list(city_set)[1]
             state_id = list(city_set)[2].upper() if list(city_set)[2] != '' else 'IL'
-            print("- model: address.locality")
-            print("  pk:",i)
-            print("  fields:")
-            print("    name: \"",city,"\"", sep='')
-            print("    postal_code: \"",zipcode,"\"", sep='')
-            print("    state: ['", state_id, "', '", country, "']", sep='')
-#            print("    state: 19313")
-            cities_pks[tuple(city_set)] = i 
-            i = i + 1
+            if zipcode != '':
+                print("- model: address.locality")
+                print("  pk:",i)
+                print("  fields:")
+                print("    name: \"",city,"\"", sep='')
+                print("    postal_code: \"",zipcode,"\"", sep='')
+                print("    state: ['", state_id, "', '", country, "']", sep='')
+#                print("    state: 19313")
+                cities_pks[tuple(city_set)] = i 
+                i = i + 1
         return cities_pks
  


### PR DESCRIPTION
Fix for issue #141

When I looked in the yaml file, the only issue I could see was that there was one locality which had name and postal_code equal to "". (It was no. 14) But, as far as I could tell, that were no address related to that locality.

This fix excludes localities that have no zip code.