### PR TITLE
Prevent default event behavior to fix cancel button functionality

### DIFF
--- a/client/src/components/CancelButton.jsx
+++ b/client/src/components/CancelButton.jsx
@@ -4,7 +4,9 @@ import Button from "../components/Button";
 import { useHistory } from "react-router-dom";
 
 const CancelButton = (props) => {
-    const goBack = () => {
+    const goBack = (e) => {
+        e.preventDefault();
+
         if (props.id) {
             history.goBack();
         } else {


### PR DESCRIPTION
@laredotornado I realized I didn't prevent default functionality on the cancel button functionality, so it would attempt to submit the form despite being the wrong button. This should now be fixed. Thanks!