### PR TITLE
Bugfix: Use correct URLs when fetching US States and Coop Types

### DIFF
--- a/client/src/components/DirectoryAddUpdate.jsx
+++ b/client/src/components/DirectoryAddUpdate.jsx
@@ -435,7 +435,7 @@ export default function DirectoryAddUpdate() {
       });
 
     // Get initial provinces (states)
-    fetch(REACT_APP_PROXY + '/api/v1/states/' + DEFAULT_COUNTRY_CODE)
+    fetch(REACT_APP_PROXY + '/api/v1/geo/states/' + DEFAULT_COUNTRY_CODE)
       .then((response) => {
         return response.json();
       })

--- a/client/src/components/ModalUpdate.jsx
+++ b/client/src/components/ModalUpdate.jsx
@@ -401,7 +401,7 @@ export default function ModalUpdate(props) {
       });
 
     // Get initial provinces (states)
-    fetch(REACT_APP_PROXY + '/api/v1/states/' + DEFAULT_COUNTRY_CODE)
+    fetch(REACT_APP_PROXY + '/api/v1/geo/states/' + DEFAULT_COUNTRY_CODE)
       .then((response) => {
         return response.json();
       })

--- a/client/src/components/Search.jsx
+++ b/client/src/components/Search.jsx
@@ -139,7 +139,7 @@ const Search = (props) => {
 
   useEffect(() => {
     // Get all possible coop types to populate search form
-    fetch(REACT_APP_PROXY + '/api/v1/coop_types/')
+    fetch(REACT_APP_PROXY + '/api/v1/coops/types/')
       .then((response) => {
         return response.json();
       })
@@ -153,7 +153,7 @@ const Search = (props) => {
 
   useEffect(() => {
     // Get initial provinces (states)
-    fetch(REACT_APP_PROXY + '/api/v1/states/' + DEFAULT_COUNTRY_CODE)
+    fetch(REACT_APP_PROXY + '/api/v1/geo/states/' + DEFAULT_COUNTRY_CODE)
       .then((response) => {
         return response.json();
       })

--- a/client/src/containers/FormContainer.jsx
+++ b/client/src/containers/FormContainer.jsx
@@ -190,7 +190,7 @@ const FormContainer = (props) => {
       });
 
     // Get all possible coop types
-    fetch(REACT_APP_PROXY + "/coop_types/")
+    fetch(REACT_APP_PROXY + "/api/v1/coops/types/")
       .then((response) => {
         return response.json();
       })


### PR DESCRIPTION
Forms were crashing on load due to 404 responses from relevant endpoints. This fixes the search form.